### PR TITLE
Change cordova-plugin-file to use release instead of git

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ cordova plugin add https://github.com/shazron/KeychainPlugin.git
 For Android, [cordova-plugin-file](https://github.com/apache/cordova-plugin-file) is required:
 
 ```
-$ cordova plugin add https://git-wip-us.apache.org/repos/asf/cordova-plugin-file.git
+$ cordova plugin add cordova-plugin-file
 ```
 
 ## Usage


### PR DESCRIPTION
Changed the docs to reference cordova-plugin-file instead of the git repo URL.  The current master is prepping for
Cordova version 5.0.0 and requires at least that version (which is not available).  Using just 'cordova-plugin-file'
will pull in the official release and work with the 4.x versions of Cordova currently available