### PR TITLE
Android and iOS methods now use JSON.stringify() and JSON.parse() for…

### DIFF
--- a/dist/ng-persist.js
+++ b/dist/ng-persist.js
@@ -69,6 +69,11 @@ var _classCallCheck = function (instance, Constructor) { if (!(instance instance
                         var deferred = $q.defer();
                         var kc = new window.Keychain();
                         kc.getForKey(function (val) {
+                            if (val !== "") {
+                                val = JSON.parse(val);
+                            } else {
+                                val = null;
+                            }
                             deferred.resolve(val);
                         }, function (err) {
                             deferred.reject(err);
@@ -80,6 +85,7 @@ var _classCallCheck = function (instance, Constructor) { if (!(instance instance
                     value: function write(namespace, key, val) {
                         var deferred = $q.defer();
                         var kc = new window.Keychain();
+                        val = JSON.stringify(val);
                         kc.setForKey(function () {
                             deferred.resolve();
                         }, function (err) {
@@ -119,7 +125,13 @@ var _classCallCheck = function (instance, Constructor) { if (!(instance instance
                             fileEntry.file(function (file) {
                                 var reader = new FileReader();
                                 reader.onloadend = function (evt) {
-                                    deferred.resolve(evt.target.result);
+                                    var res = evt.target.result;
+                                    if (res !== "") {
+                                        res = JSON.parse(res);
+                                    } else {
+                                        res = null;
+                                    }
+                                    deferred.resolve(res);
                                 };
                                 reader.readAsText(file);
                             });
@@ -140,7 +152,7 @@ var _classCallCheck = function (instance, Constructor) { if (!(instance instance
                                 }
                                 file.createWriter(function (fileWriter) {
                                     // fileWriter.seek(fileWriter.length);
-                                    var blob = new Blob([val], { type: "text/plain" });
+                                    var blob = new Blob([JSON.stringify(val)], { type: "text/plain" });
                                     fileWriter.write(blob);
                                     deferred.resolve();
                                 }, function (err) {

--- a/src/ng-persist.js
+++ b/src/ng-persist.js
@@ -43,6 +43,11 @@
                 const deferred = $q.defer();
                 const kc = new window.Keychain();
                 kc.getForKey((val) => {
+                        if (val !== "") {
+                            val = JSON.parse(val)
+                        } else {
+                            val = null;
+                        }
                         deferred.resolve(val);
                     }, (err) => {
                         deferred.reject(err);
@@ -52,6 +57,7 @@
             write(namespace, key, val) {
                 const deferred = $q.defer();
                 const kc = new window.Keychain();
+                val = JSON.stringify(val);
                 kc.setForKey(() => {
                     deferred.resolve();
                 }, (err) => {
@@ -79,7 +85,13 @@
                     fileEntry.file((file) => {
                         const reader = new FileReader();
                         reader.onloadend = (evt) => {
-                            deferred.resolve(evt.target.result);
+                            var res = evt.target.result;
+                            if (res !== "") {
+                                res = JSON.parse(res)
+                            } else {
+                                res = null;
+                            }
+                            deferred.resolve(res);
                         };
                         reader.readAsText(file);
                     });
@@ -98,7 +110,7 @@
                         }
                         file.createWriter((fileWriter) => {
                             // fileWriter.seek(fileWriter.length);
-                            const blob = new Blob([val], { type:'text/plain' });
+                            const blob = new Blob([JSON.stringify(val)], { type:'text/plain' });
                             fileWriter.write(blob);
                             deferred.resolve();
                         }, (err) => {


### PR DESCRIPTION
… persisting data

 - original code only worked for simple strings on Android and iOS, even though arrays and objects worked fine in local storage
 - also return null instead of "" on non-existant object reads on Android and iOS to be consistent with local storage (ie. asking to read an object that was never saved)