### PR TITLE
Fix parenthesis. Update build tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 npm-debug.log
+.idea

--- a/dist/ng-persist.js
+++ b/dist/ng-persist.js
@@ -1,193 +1,190 @@
-"use strict";
+'use strict';
 
-var _createClass = (function () { function defineProperties(target, props) { for (var key in props) { var prop = props[key]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 (function () {
 
-    "use strict";
+    'use strict';
 
-    angular.module("ng-persist", []);
+    angular.module('ng-persist', []);
 
-    var $persist = function ($q, $localStorage) {
+    var $persist = function $persist($q, $localStorage) {
 
         var isBrowser = false;
         var isIos = false;
         var isAndroid = false;
 
-        if (!window.cordova && !window.device && (typeof Keychain === 'undefined')) {
+        if (!window.cordova && !window.device && typeof Keychain === 'undefined') {
             isBrowser = true;
         } else {
-            isAndroid = window.device.platform === "Android";
-            isIos = window.device.platform === "iOS";
+            isAndroid = window.device.platform === 'Android';
+            isIos = window.device.platform === 'iOS';
         }
 
-        var LocalStorageAdapter = (function () {
+        var LocalStorageAdapter = function () {
             function LocalStorageAdapter() {
                 _classCallCheck(this, LocalStorageAdapter);
             }
 
-            _createClass(LocalStorageAdapter, {
-                read: {
-                    value: function read(namespace, key) {
-                        var deferred = $q.defer();
-                        var val = $localStorage["" + namespace + "_" + key];
-                        deferred.resolve(val);
-                        return deferred.promise;
-                    }
-                },
-                write: {
-                    value: function write(namespace, key, val) {
-                        var deferred = $q.defer();
-                        $localStorage["" + namespace + "_" + key] = val;
-                        deferred.resolve();
-                        return deferred.promise;
-                    }
-                },
-                remove: {
-                    value: function remove(namespace, key) {
-                        var deferred = $q.defer();
-                        delete $localStorage["" + namespace + "_" + key];
-                        deferred.resolve();
-                        return deferred.promise;
-                    }
+            _createClass(LocalStorageAdapter, [{
+                key: 'read',
+                value: function read(namespace, key) {
+                    var deferred = $q.defer();
+                    var val = $localStorage[namespace + '_' + key];
+                    deferred.resolve(val);
+                    return deferred.promise;
                 }
-            });
+            }, {
+                key: 'write',
+                value: function write(namespace, key, val) {
+                    var deferred = $q.defer();
+                    $localStorage[namespace + '_' + key] = val;
+                    deferred.resolve();
+                    return deferred.promise;
+                }
+            }, {
+                key: 'remove',
+                value: function remove(namespace, key) {
+                    var deferred = $q.defer();
+                    delete $localStorage[namespace + '_' + key];
+                    deferred.resolve();
+                    return deferred.promise;
+                }
+            }]);
 
             return LocalStorageAdapter;
-        })();
+        }();
 
-        var IosKeychainAdapter = (function () {
+        var IosKeychainAdapter = function () {
             function IosKeychainAdapter() {
                 _classCallCheck(this, IosKeychainAdapter);
             }
 
-            _createClass(IosKeychainAdapter, {
-                read: {
-                    value: function read(namespace, key) {
-                        var deferred = $q.defer();
-                        Keychain.get(function (val) {
-                            if (val !== "") {
-                                val = JSON.parse(val);
-                            } else {
-                                val = null;
-                            }
-                            deferred.resolve(val);
-                        }, function (err) {
-                            deferred.reject(err);
-                        }, key, '');
-                        return deferred.promise;
-                    }
-                },
-                write: {
-                    value: function write(namespace, key, val) {
-                        var deferred = $q.defer();
-                        val = JSON.stringify(val);
-                        Keychain.set(function () {
-                            deferred.resolve();
-                        }, function (err) {
-                            deferred.reject(err);
-                        }, key, val, false);
-                        return deferred.promise;
-                    }
-                },
-                remove: {
-                    value: function remove(namespace, key) {
-                        var deferred = $q.defer();
-                        Keychain.remove(function () {
-                            deferred.resolve();
-                        }, function (err) {
-                            deferred.reject(err);
-                        }, key);
-                        return deferred.promise;
-                    }
+            _createClass(IosKeychainAdapter, [{
+                key: 'read',
+                value: function read(namespace, key) {
+                    var deferred = $q.defer();
+                    Keychain.get(function (val) {
+                        if (val !== "") {
+                            val = JSON.parse(val);
+                        } else {
+                            val = null;
+                        }
+                        deferred.resolve(val);
+                    }, function (err) {
+                        deferred.reject(err);
+                    }, key, '');
+                    return deferred.promise;
                 }
-            });
+            }, {
+                key: 'write',
+                value: function write(namespace, key, val) {
+                    var deferred = $q.defer();
+                    val = JSON.stringify(val);
+                    Keychain.set(function () {
+                        deferred.resolve();
+                    }, function (err) {
+                        deferred.reject(err);
+                    }, key, val, false);
+                    return deferred.promise;
+                }
+            }, {
+                key: 'remove',
+                value: function remove(namespace, key) {
+                    var deferred = $q.defer();
+                    Keychain.remove(function () {
+                        deferred.resolve();
+                    }, function (err) {
+                        deferred.reject(err);
+                    }, key);
+                    return deferred.promise;
+                }
+            }]);
 
             return IosKeychainAdapter;
-        })();
+        }();
 
-        var AndroidExternalStorageAdapter = (function () {
+        var AndroidExternalStorageAdapter = function () {
             function AndroidExternalStorageAdapter() {
                 _classCallCheck(this, AndroidExternalStorageAdapter);
             }
 
-            _createClass(AndroidExternalStorageAdapter, {
-                read: {
-                    value: function read(namespace, key) {
-                        var deferred = $q.defer();
-                        var filename = "" + namespace + "_" + key;
-                        window.resolveLocalFileSystemURL(cordova.file.externalRootDirectory + filename, function (fileEntry) {
-                            fileEntry.file(function (file) {
-                                var reader = new FileReader();
-                                reader.onloadend = function (evt) {
-                                    var res = evt.target.result;
-                                    if (res !== "") {
-                                        res = JSON.parse(res);
-                                    } else {
-                                        res = null;
-                                    }
-                                    deferred.resolve(res);
-                                };
-                                reader.readAsText(file);
-                            });
-                        }, function (err) {
-                            deferred.reject(err);
-                        });
-                        return deferred.promise;
-                    }
-                },
-                write: {
-                    value: function write(namespace, key, val) {
-                        var deferred = $q.defer();
-                        window.resolveLocalFileSystemURL(cordova.file.externalRootDirectory, function (dir) {
-                            var filename = "" + namespace + "_" + key;
-                            dir.getFile(filename, { create: true }, function (file) {
-                                if (!file) {
-                                    deferred.reject();
+            _createClass(AndroidExternalStorageAdapter, [{
+                key: 'read',
+                value: function read(namespace, key) {
+                    var deferred = $q.defer();
+                    var filename = namespace + '_' + key;
+                    window.resolveLocalFileSystemURL(cordova.file.externalRootDirectory + filename, function (fileEntry) {
+                        fileEntry.file(function (file) {
+                            var reader = new FileReader();
+                            reader.onloadend = function (evt) {
+                                var res = evt.target.result;
+                                if (res !== "") {
+                                    res = JSON.parse(res);
+                                } else {
+                                    res = null;
                                 }
-                                file.createWriter(function (fileWriter) {
-                                    // fileWriter.seek(fileWriter.length);
-                                    var blob = new Blob([JSON.stringify(val)], { type: "text/plain" });
-                                    fileWriter.write(blob);
-                                    deferred.resolve();
-                                }, function (err) {
-                                    deferred.reject(err);
-                                });
-                            });
+                                deferred.resolve(res);
+                            };
+                            reader.readAsText(file);
                         });
-                        return deferred.promise;
-                    }
-                },
-                remove: {
-                    value: function remove(namespace, key) {
-                        var deferred = $q.defer();
-                        window.resolveLocalFileSystemURL(cordova.file.externalRootDirectory, function (dir) {
-                            var filename = "" + namespace + "_" + key;
-                            dir.getFile(filename, { create: true }, function (file) {
-                                if (!file) {
-                                    deferred.reject();
-                                }
-                                file.createWriter(function (fileWriter) {
-                                    // fileWriter.seek(fileWriter.length);
-                                    var blob = new Blob([""], { type: "text/plain" });
-                                    fileWriter.write(blob);
-                                    deferred.resolve();
-                                }, function (err) {
-                                    deferred.reject(err);
-                                });
-                            });
-                        });
-                        return deferred.promise;
-                    }
+                    }, function (err) {
+                        deferred.reject(err);
+                    });
+                    return deferred.promise;
                 }
-            });
+            }, {
+                key: 'write',
+                value: function write(namespace, key, val) {
+                    var deferred = $q.defer();
+                    window.resolveLocalFileSystemURL(cordova.file.externalRootDirectory, function (dir) {
+                        var filename = namespace + '_' + key;
+                        dir.getFile(filename, { create: true }, function (file) {
+                            if (!file) {
+                                deferred.reject();
+                            }
+                            file.createWriter(function (fileWriter) {
+                                // fileWriter.seek(fileWriter.length);
+                                var blob = new Blob([JSON.stringify(val)], { type: 'text/plain' });
+                                fileWriter.write(blob);
+                                deferred.resolve();
+                            }, function (err) {
+                                deferred.reject(err);
+                            });
+                        });
+                    });
+                    return deferred.promise;
+                }
+            }, {
+                key: 'remove',
+                value: function remove(namespace, key) {
+                    var deferred = $q.defer();
+                    window.resolveLocalFileSystemURL(cordova.file.externalRootDirectory, function (dir) {
+                        var filename = namespace + '_' + key;
+                        dir.getFile(filename, { create: true }, function (file) {
+                            if (!file) {
+                                deferred.reject();
+                            }
+                            file.createWriter(function (fileWriter) {
+                                // fileWriter.seek(fileWriter.length);
+                                var blob = new Blob([''], { type: 'text/plain' });
+                                fileWriter.write(blob);
+                                deferred.resolve();
+                            }, function (err) {
+                                deferred.reject(err);
+                            });
+                        });
+                    });
+                    return deferred.promise;
+                }
+            }]);
 
             return AndroidExternalStorageAdapter;
-        })();
+        }();
 
-        var getAdapter = function () {
+        var getAdapter = function getAdapter() {
             if (isBrowser) {
                 return new LocalStorageAdapter();
             } else if (isIos) {
@@ -199,15 +196,15 @@ var _classCallCheck = function (instance, Constructor) { if (!(instance instance
 
         return {
             set: function set() {
-                var namespace = arguments[0] === undefined ? "" : arguments[0];
-                var key = arguments[1] === undefined ? null : arguments[1];
-                var val = arguments[2] === undefined ? "" : arguments[2];
+                var namespace = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
+                var key = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+                var val = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : '';
 
                 var deferred = $q.defer();
                 var adapter = getAdapter();
                 adapter.write(namespace, key, val).then(function () {
                     deferred.resolve(val);
-                })["catch"](function (err) {
+                }).catch(function (err) {
                     // if not browser, write to local storage
                     // otherwise reject
                     if (!isBrowser) {
@@ -220,9 +217,9 @@ var _classCallCheck = function (instance, Constructor) { if (!(instance instance
                 return deferred.promise;
             },
             get: function get() {
-                var namespace = arguments[0] === undefined ? "" : arguments[0];
-                var key = arguments[1] === undefined ? null : arguments[1];
-                var fallback = arguments[2] === undefined ? "" : arguments[2];
+                var namespace = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
+                var key = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+                var fallback = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : '';
 
                 var deferred = $q.defer();
                 var adapter = getAdapter();
@@ -232,7 +229,7 @@ var _classCallCheck = function (instance, Constructor) { if (!(instance instance
                     } else {
                         deferred.resolve(fallback);
                     }
-                })["catch"](function () {
+                }).catch(function () {
                     // always resolve with the fallback value
                     deferred.resolve(fallback);
                 });
@@ -241,8 +238,9 @@ var _classCallCheck = function (instance, Constructor) { if (!(instance instance
             remove: function remove(namespace, key) {
                 var adapter = getAdapter();
                 return adapter.remove(namespace, key);
-            } };
+            }
+        };
     };
-    $persist.$inject = ["$q", "$localStorage"];
-    angular.module("ng-persist").factory("$persist", $persist);
+    $persist.$inject = ['$q', '$localStorage'];
+    angular.module('ng-persist').factory('$persist', $persist);
 })();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,9 @@ var babel         = require('gulp-babel');
             .src(paths.src)
             .pipe(plumber())
             .pipe(ngAnnotate())
-            .pipe(babel())
+            .pipe(babel({
+                presets: ['es2015']
+            }))
             .pipe(concat('ng-persist.js'))
             .pipe(gulp.dest(paths.dist));
     };

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
   },
   "homepage": "https://github.com/AlexDisler/ng-persist",
   "dependencies": {
-    "gulp": "3.8.11",
-    "gulp-babel": "4.0.0",
-    "gulp-concat": "2.5.2",
-    "gulp-ng-annotate": "0.5.2",
-    "gulp-plumber": "1.0.0"
+    "babel-preset-es2015": "6.22.0",
+    "gulp": "3.9.1",
+    "gulp-babel": "6.1.2",
+    "gulp-concat": "2.6.1",
+    "gulp-ng-annotate": "2.0.0",
+    "gulp-plumber": "1.1.0"
   }
 }

--- a/src/ng-persist.js
+++ b/src/ng-persist.js
@@ -197,4 +197,4 @@
     $persist.$inject = ['$q', '$localStorage'];
     angular.module('ng-persist').factory('$persist', $persist);
 
-}());
+})();


### PR DESCRIPTION
The current master branch version does not work in Chrome right now.
Accessing the read/write/remove methods in the adapters is not possible.
This is most likely because of the outdated babel setup.

This PR updates the dependencies to the latest versions, and includes the rebuilt library.